### PR TITLE
Enforce Minimum Collateral Ratio Validation

### DIFF
--- a/src/vUSD.sol
+++ b/src/vUSD.sol
@@ -16,7 +16,8 @@ contract vUSD is ERC20, Ownable, ReentrancyGuard {
     //////////////////////////////////////////////////////////////*/
 
     // Protocol config
-    uint256 public collateralRatio; // 1e18 precision
+    uint256 public constant MIN_COLLATERAL_RATIO = 1e18;
+    uint256 public collateralRatio = 1e18;
     mapping(address => bool) public isAllowedCollateral;
     mapping(address => uint256) public collateralPrice;
 
@@ -96,7 +97,9 @@ contract vUSD is ERC20, Ownable, ReentrancyGuard {
     //////////////////////////////////////////////////////////////*/
 
     function _validateCollateralRatio(uint256 newRatio) internal pure {
-        if (newRatio == 0) revert InvalidCollateralRatio(newRatio);
+        if (newRatio < MIN_COLLATERAL_RATIO) {
+            revert InvalidCollateralRatio(newRatio);
+        }
     }
 
     function _validateCollateralPrice(uint256 price) internal pure {

--- a/test/vUSD.t.sol
+++ b/test/vUSD.t.sol
@@ -23,7 +23,7 @@ contract vUSDTest is Test {
         uint256 newRatio = 1.5e18;
 
         vm.expectEmit(true, false, false, true);
-        emit vUSD.CollateralRatioUpdated(0, newRatio); // old = 0 for first set
+        emit vUSD.CollateralRatioUpdated(1e18, newRatio); // old = 1e18 for first set
 
         token.setCollateralRatio(newRatio);
 
@@ -39,6 +39,13 @@ contract vUSDTest is Test {
     function testCollateralRatioCannotBeZero() public {
         vm.expectRevert(abi.encodeWithSelector(vUSD.InvalidCollateralRatio.selector, 0));
         token.setCollateralRatio(0);
+    }
+
+    function testSetCollateralRatioBelow100Reverts() public {
+        uint256 invalidRatio = 9e17; // 90%
+
+        vm.expectRevert(abi.encodeWithSelector(vUSD.InvalidCollateralRatio.selector, invalidRatio));
+        token.setCollateralRatio(invalidRatio);
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
This change enforces failing when the collateral ratio is set below the constant minimum, and adds a test for it.

Tests for:
* Collateral ratio cannot be zero
* Collateral ratio above the minimum can be set
were already implemented in prior work.